### PR TITLE
Hack for distutils check --restructuredtext

### DIFF
--- a/docutils/docutils/frontend.py
+++ b/docutils/docutils/frontend.py
@@ -29,6 +29,7 @@ Also exports the following functions:
 
 __docformat__ = 'reStructuredText'
 
+import inspect
 import os
 import os.path
 import sys
@@ -41,6 +42,7 @@ import docutils
 import docutils.utils
 import docutils.nodes
 from docutils.utils.error_reporting import locale_encoding, ErrorOutput, ErrorString
+from docutils.parsers import Parser
 
 
 def store_multiple(option, opt, value, parser, *args, **kwargs):
@@ -562,6 +564,19 @@ class OptionParser(optparse.OptionParser, docutils.SettingsSpec):
         # Make an instance copy (it will be modified):
         self.relative_path_settings = list(self.relative_path_settings)
         self.components = (self,) + tuple(components)
+
+        # distutils.command.check does:
+        # settings = frontend.OptionParser().get_default_values()
+        # and as a result is missing important defaults like
+        # `syntax_highlight`, causing
+        # `python setup.py check --restructuredtext --strict --metadata` to
+        # fail with `warning: check: Could not finish the parsing.` if the RST
+        # document uses `code` or `code-block` directives.
+        # See http://bugs.python.org/issue23063
+        if len(components) == 0 and self.called_by_distutils_check():
+            from docutils.parsers.rst import Parser as RSTParser
+            self.components += (RSTParser,)
+
         self.populate_from_components(self.components)
         self.set_defaults_from_dict(defaults or {})
         if read_config_files and not self.defaults['_disable_config']:
@@ -570,6 +585,19 @@ class OptionParser(optparse.OptionParser, docutils.SettingsSpec):
             except ValueError, error:
                 self.error(error)
             self.set_defaults_from_dict(config_settings.__dict__)
+
+    def called_by_distutils_check(self):
+        frame = inspect.currentframe()
+
+        while frame:
+            filename = frame.f_code.co_filename
+            func_name = frame.f_code.co_name
+            if 'distutils' in filename:
+                if func_name == 'check_restructuredtext':
+                    return True
+            frame = frame.f_back
+
+        return False
 
     def populate_from_components(self, components):
         """


### PR DESCRIPTION
A Python distutils bug (http://bugs.python.org/issue23063) causes
`python setup.py check --restructuredtext` to fail on documents with
code blocks.

Fixes: SF-270 (https://sourceforge.net/p/docutils/bugs/270/)

---

`python setup.py check --restructuredtext --strict --metadata` fails with:

```
warning: check: Could not finish the parsing.
```

if the RST document uses `code` or `code-block` directives.

This is annoying because the document is valid, but it appears to be invalid and confuses people. For an example, see https://github.com/ionelmc/pytest-benchmark/pull/4#issuecomment-66940307.
## How to reproduce this bug

Clone a repo that has a `README.rst` with `code-block` directives in it. E.g.:

``` bash
$ git clone git@github.com:ionelmc/pytest-benchmark.git
$ cd pytest-benchmark
$ git checkout ab0b08f6fccb06a7909905a8409f8faa8b01e0d8
```

   Observe that it has "code-blocks" in it:

```
   $ grep 'code-block' README.rst
   .. code-block:: python
   .. code-block:: python
```

Observe that RST document is valid, according to `rst2html.py`:

```
   $ rst2html.py --halt=1 README.rst > README.html && echo "RST was OK."
   RST was OK.

   $ head -n 3 README.html
   <?xml version="1.0" encoding="utf-8" ?>
   <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
   <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
```

Observe that `python setup.py check --restructuredtext --strict --metadata` fails:

```
$ python setup.py check --restructuredtext --strict --metadata
running check
warning: check: Could not finish the parsing.

error: Please correct your package.

$ echo $?
1
```

**What was expected**: `python setup.py check --restructuredtext --strict
--metadata` should succeed with no warnings, just as `rst2html.py did`, because
`README.rst` is a valid RST document.

**What actually happened**: `python setup.py check --restructuredtext --strict
--metadata` prints a warning and an error and fails, unlike `rst2html.py`

The error is coming from here:
https://github.com/python/cpython/blob/master/Lib/distutils/command/check.py#L142

It's happening because of this line:
https://github.com/python/cpython/blob/master/Lib/distutils/command/check.py#L125

``` python
settings = frontend.OptionParser().get_default_values()
```

If this is changed to:

``` python
settings = frontend.OptionParser(components=(Parser,)).get_default_values()
```

then things work much better (this is how `tools/quicktest.py` does it for example)

so this _might_ actually be a bug in distutils, but changing CPython (and maybe PyPy) is a more laborious and slow process, so I'm thinking it might be nice to work around this in docutils, if isn't too much of a burden. Docutils is on a much shorter release cycle than CPython, so changing docutils is a way to get this fix out to users much faster.
